### PR TITLE
Added support for sandbox flag; made tests less verbose by default; added toString() to responses

### DIFF
--- a/src/main/java/io/kraken/client/impl/DefaultKrakenIoClient.java
+++ b/src/main/java/io/kraken/client/impl/DefaultKrakenIoClient.java
@@ -30,7 +30,6 @@ import io.kraken.client.model.response.AbstractUploadResponse;
 import io.kraken.client.model.response.FailedUploadResponse;
 import io.kraken.client.model.response.SuccessfulUploadCallbackUrlResponse;
 import io.kraken.client.model.response.SuccessfulUploadResponse;
-import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -44,7 +43,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
 import java.text.MessageFormat;
 import java.util.UUID;
 

--- a/src/main/java/io/kraken/client/model/request/AbstractUploadCallbackUrlRequest.java
+++ b/src/main/java/io/kraken/client/model/request/AbstractUploadCallbackUrlRequest.java
@@ -23,7 +23,6 @@ import io.kraken.client.model.resize.AbstractResize;
 import java.net.URL;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -35,14 +34,15 @@ public abstract class AbstractUploadCallbackUrlRequest extends AbstractUploadReq
     @JsonProperty("callback_url")
     private final URL callbackUrl;
 
-    protected AbstractUploadCallbackUrlRequest(Boolean webp,
+    protected AbstractUploadCallbackUrlRequest(Boolean dev,
+                                               Boolean webp,
                                                Boolean lossy,
                                                Integer quality,
                                                AbstractResize resize,
                                                Set<Metadata> preserveMeta,
                                                Convert convert,
                                                URL callbackUrl) {
-        super(false, webp, lossy, quality, resize, preserveMeta, convert);
+        super(dev, false, webp, lossy, quality, resize, preserveMeta, convert);
 
         checkNotNull(callbackUrl, "callbackUrl must not be null");
         this.callbackUrl = callbackUrl;

--- a/src/main/java/io/kraken/client/model/request/AbstractUploadRequest.java
+++ b/src/main/java/io/kraken/client/model/request/AbstractUploadRequest.java
@@ -21,8 +21,6 @@ import io.kraken.client.model.Convert;
 import io.kraken.client.model.Metadata;
 import io.kraken.client.model.resize.AbstractResize;
 
-import java.net.URL;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -35,6 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public abstract class AbstractUploadRequest {
 
+    private final Boolean dev;
     private final Boolean wait;
     private final Boolean webp;
     private final Boolean lossy;
@@ -45,18 +44,21 @@ public abstract class AbstractUploadRequest {
     private final Convert convert;
 
     @JsonCreator
-    protected AbstractUploadRequest(Boolean wait,
+    protected AbstractUploadRequest(Boolean dev,
+                                    Boolean wait,
                                     Boolean webp,
                                     Boolean lossy,
                                     Integer quality,
                                     AbstractResize resize,
                                     Set<Metadata> preserveMeta,
                                     Convert convert) {
+        checkNotNull(dev, "dev must not be null");
         checkNotNull(wait, "wait must not be null");
         checkNotNull(lossy, "lossy must not be null");
         checkArgument(quality == null || (quality != null && quality >= 1 && quality <= 100), "quality must be between 1-100");
         checkArgument(lossy != null || (lossy == null && quality == null), "quality can only be set if lossy is set");
 
+        this.dev = dev;
         this.wait = wait;
         this.webp = webp;
         this.lossy = lossy;
@@ -64,6 +66,10 @@ public abstract class AbstractUploadRequest {
         this.resize = resize;
         this.preserveMeta = preserveMeta;
         this.convert = convert;
+    }
+
+    public Boolean getDev() {
+        return dev;
     }
 
     public Boolean getWait() {
@@ -97,6 +103,7 @@ public abstract class AbstractUploadRequest {
     protected static class Builder<T extends Builder> {
         protected final Class<T> clazz;
 
+        protected Boolean dev = false;
         protected Boolean webp = false;
         protected Boolean lossy = false;
         protected Integer quality;
@@ -114,6 +121,11 @@ public abstract class AbstractUploadRequest {
                 this.quality = null;
             }
 
+            return clazz.cast(this);
+        }
+
+        public T withDev(boolean dev) {
+            this.dev = dev;
             return clazz.cast(this);
         }
 

--- a/src/main/java/io/kraken/client/model/request/DirectFileUploadCallbackUrlRequest.java
+++ b/src/main/java/io/kraken/client/model/request/DirectFileUploadCallbackUrlRequest.java
@@ -35,7 +35,8 @@ public class DirectFileUploadCallbackUrlRequest extends AbstractUploadCallbackUr
     @JsonIgnore
     private final File image;
 
-    private DirectFileUploadCallbackUrlRequest(Boolean webp,
+    private DirectFileUploadCallbackUrlRequest(Boolean dev,
+                                               Boolean webp,
                                                Boolean lossy,
                                                Integer quality,
                                                AbstractResize resize,
@@ -43,7 +44,7 @@ public class DirectFileUploadCallbackUrlRequest extends AbstractUploadCallbackUr
                                                Convert convert,
                                                URL callbackUrl,
                                                File image) {
-        super(webp, lossy, quality, resize, preserveMeta, convert, callbackUrl);
+        super(dev, webp, lossy, quality, resize, preserveMeta, convert, callbackUrl);
 
         checkNotNull(image, "image must not be null");
         this.image = image;
@@ -67,6 +68,7 @@ public class DirectFileUploadCallbackUrlRequest extends AbstractUploadCallbackUr
 
         public DirectFileUploadCallbackUrlRequest build() {
             return new DirectFileUploadCallbackUrlRequest(
+                    dev,
                     webp,
                     lossy,
                     quality,

--- a/src/main/java/io/kraken/client/model/request/DirectFileUploadRequest.java
+++ b/src/main/java/io/kraken/client/model/request/DirectFileUploadRequest.java
@@ -21,7 +21,6 @@ import io.kraken.client.model.Metadata;
 import io.kraken.client.model.resize.AbstractResize;
 
 import java.io.File;
-import java.net.URL;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -35,14 +34,15 @@ public class DirectFileUploadRequest extends AbstractUploadRequest {
     @JsonIgnore
     private final File image;
 
-    private DirectFileUploadRequest(Boolean webp,
+    private DirectFileUploadRequest(Boolean dev,
+                                    Boolean webp,
                                     Boolean lossy,
                                     Integer quality,
                                     AbstractResize resize,
                                     Set<Metadata> preserveMeta,
                                     Convert convert,
                                     File image) {
-        super(true, webp, lossy, quality, resize, preserveMeta, convert);
+        super(dev, true, webp, lossy, quality, resize, preserveMeta, convert);
 
         checkNotNull(image, "image must not be null");
         this.image = image;
@@ -66,6 +66,7 @@ public class DirectFileUploadRequest extends AbstractUploadRequest {
 
         public DirectFileUploadRequest build() {
             return new DirectFileUploadRequest(
+                    dev,
                     webp,
                     lossy,
                     quality,

--- a/src/main/java/io/kraken/client/model/request/DirectUploadCallbackUrlRequest.java
+++ b/src/main/java/io/kraken/client/model/request/DirectUploadCallbackUrlRequest.java
@@ -16,7 +16,6 @@
 package io.kraken.client.model.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kraken.client.model.Convert;
 import io.kraken.client.model.Metadata;
 import io.kraken.client.model.resize.AbstractResize;
@@ -36,7 +35,8 @@ public class DirectUploadCallbackUrlRequest extends AbstractUploadCallbackUrlReq
     @JsonIgnore
     private final InputStream image;
 
-    private DirectUploadCallbackUrlRequest(Boolean webp,
+    private DirectUploadCallbackUrlRequest(Boolean dev,
+                                           Boolean webp,
                                            Boolean lossy,
                                            Integer quality,
                                            AbstractResize resize,
@@ -44,7 +44,7 @@ public class DirectUploadCallbackUrlRequest extends AbstractUploadCallbackUrlReq
                                            Convert convert,
                                            URL callbackUrl,
                                            InputStream image) {
-        super(webp, lossy, quality, resize, preserveMeta, convert, callbackUrl);
+        super(dev, webp, lossy, quality, resize, preserveMeta, convert, callbackUrl);
 
         checkNotNull(image, "image must not be null");
         this.image = image;
@@ -68,6 +68,7 @@ public class DirectUploadCallbackUrlRequest extends AbstractUploadCallbackUrlReq
 
         public DirectUploadCallbackUrlRequest build() {
             return new DirectUploadCallbackUrlRequest(
+                    dev,
                     webp,
                     lossy,
                     quality,

--- a/src/main/java/io/kraken/client/model/request/DirectUploadRequest.java
+++ b/src/main/java/io/kraken/client/model/request/DirectUploadRequest.java
@@ -16,16 +16,13 @@
 package io.kraken.client.model.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kraken.client.model.Convert;
 import io.kraken.client.model.Metadata;
 import io.kraken.client.model.resize.AbstractResize;
 
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -37,14 +34,15 @@ public class DirectUploadRequest extends AbstractUploadRequest {
     @JsonIgnore
     private final InputStream image;
 
-    private DirectUploadRequest(Boolean webp,
+    private DirectUploadRequest(Boolean dev,
+                                Boolean webp,
                                 Boolean lossy,
                                 Integer quality,
                                 AbstractResize resize,
                                 Set<Metadata> preserveMeta,
                                 Convert convert,
                                 InputStream image) {
-        super(true, webp, lossy, quality, resize, preserveMeta, convert);
+        super(dev, true, webp, lossy, quality, resize, preserveMeta, convert);
 
         checkNotNull(image, "image must not be null");
         this.image = image;
@@ -68,6 +66,7 @@ public class DirectUploadRequest extends AbstractUploadRequest {
 
         public DirectUploadRequest build() {
             return new DirectUploadRequest(
+                    dev,
                     webp,
                     lossy,
                     quality,

--- a/src/main/java/io/kraken/client/model/request/ImageUrlUploadCallbackUrlRequest.java
+++ b/src/main/java/io/kraken/client/model/request/ImageUrlUploadCallbackUrlRequest.java
@@ -34,7 +34,8 @@ public class ImageUrlUploadCallbackUrlRequest extends AbstractUploadCallbackUrlR
     @JsonProperty("url")
     private final URL imageUrl;
 
-    private ImageUrlUploadCallbackUrlRequest(Boolean webp,
+    private ImageUrlUploadCallbackUrlRequest(Boolean dev,
+                                             Boolean webp,
                                              Boolean lossy,
                                              Integer quality,
                                              AbstractResize resize,
@@ -42,7 +43,7 @@ public class ImageUrlUploadCallbackUrlRequest extends AbstractUploadCallbackUrlR
                                              Convert convert,
                                              URL callbackUrl,
                                              URL imageUrl) {
-        super(webp, lossy, quality, resize, preserveMeta, convert, callbackUrl);
+        super(dev, webp, lossy, quality, resize, preserveMeta, convert, callbackUrl);
 
         checkNotNull(imageUrl, "imageUrl must not be null");
         this.imageUrl = imageUrl;
@@ -66,6 +67,7 @@ public class ImageUrlUploadCallbackUrlRequest extends AbstractUploadCallbackUrlR
 
         public ImageUrlUploadCallbackUrlRequest build() {
             return new ImageUrlUploadCallbackUrlRequest(
+                    dev,
                     webp,
                     lossy,
                     quality,

--- a/src/main/java/io/kraken/client/model/request/ImageUrlUploadRequest.java
+++ b/src/main/java/io/kraken/client/model/request/ImageUrlUploadRequest.java
@@ -34,14 +34,15 @@ public class ImageUrlUploadRequest extends AbstractUploadRequest {
     @JsonProperty("url")
     private final URL imageUrl;
 
-    private ImageUrlUploadRequest(Boolean webp,
+    private ImageUrlUploadRequest(Boolean dev,
+                                  Boolean webp,
                                   Boolean lossy,
                                   Integer quality,
                                   AbstractResize resize,
                                   Set<Metadata> preserveMeta,
                                   Convert convert,
                                   URL imageUrl) {
-        super(true, webp, lossy, quality, resize, preserveMeta, convert);
+        super(dev, true, webp, lossy, quality, resize, preserveMeta, convert);
 
         checkNotNull(imageUrl, "imageUrl must not be null");
         this.imageUrl = imageUrl;
@@ -65,6 +66,7 @@ public class ImageUrlUploadRequest extends AbstractUploadRequest {
 
         public ImageUrlUploadRequest build() {
             return new ImageUrlUploadRequest(
+                    dev,
                     webp,
                     lossy,
                     quality,

--- a/src/main/java/io/kraken/client/model/response/AbstractUploadResponse.java
+++ b/src/main/java/io/kraken/client/model/response/AbstractUploadResponse.java
@@ -16,6 +16,7 @@
 package io.kraken.client.model.response;
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Emir Dizdarevic
@@ -27,6 +28,9 @@ import com.fasterxml.jackson.annotation.*;
         @JsonSubTypes.Type(value = FailedUploadResponse.class, name = "false")
 })
 public abstract class AbstractUploadResponse {
+
+    @JsonIgnore
+    protected final ObjectMapper objectMapper = new ObjectMapper();
 
     private final Boolean success;
 

--- a/src/main/java/io/kraken/client/model/response/FailedUploadResponse.java
+++ b/src/main/java/io/kraken/client/model/response/FailedUploadResponse.java
@@ -17,6 +17,7 @@ package io.kraken.client.model.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * @author Emir Dizdarevic
@@ -35,5 +36,18 @@ public class FailedUploadResponse extends AbstractUploadResponse {
 
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return "AbstractUploadResponse:" + objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            return "SuccessfulUploadResponse{" +
+                    "success='" + getSuccess() + '\'' +
+                    ", status='" + getStatus() + '\'' +
+                    ", status='" + getMessage() + '\'' +
+                    '}';
+        }
     }
 }

--- a/src/main/java/io/kraken/client/model/response/SuccessfulUploadCallbackUrlResponse.java
+++ b/src/main/java/io/kraken/client/model/response/SuccessfulUploadCallbackUrlResponse.java
@@ -16,13 +16,19 @@
 package io.kraken.client.model.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Emir Dizdarevic
  * @since 1.0.0
  */
 public class SuccessfulUploadCallbackUrlResponse {
+
+    @JsonIgnore
+    protected final ObjectMapper objectMapper = new ObjectMapper();
 
     private final String id;
 
@@ -33,5 +39,16 @@ public class SuccessfulUploadCallbackUrlResponse {
 
     public String getId() {
         return id;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return "AbstractUploadResponse:" + objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            return "SuccessfulUploadCallbackUrlResponse{" +
+                    "id='" + id + '\'' +
+                    '}';
+        }
     }
 }

--- a/src/main/java/io/kraken/client/model/response/SuccessfulUploadResponse.java
+++ b/src/main/java/io/kraken/client/model/response/SuccessfulUploadResponse.java
@@ -17,6 +17,7 @@ package io.kraken.client.model.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * @author Emir Dizdarevic
@@ -63,5 +64,22 @@ public class SuccessfulUploadResponse extends AbstractUploadResponse {
 
     public String getKrakedUrl() {
         return krakedUrl;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return "AbstractUploadResponse:" + objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            return "SuccessfulUploadResponse{" +
+                    "success='" + getSuccess() + '\'' +
+                    ", status='" + getStatus() + '\'' +
+                    ", fileName='" + getFileName() + '\'' +
+                    ", originalSize=" + getOriginalSize() +
+                    ", krakedSize=" + getKrakedSize() +
+                    ", savedBytes=" + getSavedBytes() +
+                    ", krakedUrl='" + getKrakedUrl() + '\'' +
+                    '}';
+        }
     }
 }

--- a/src/test/java/io/kraken/client/impl/ManualTest.java
+++ b/src/test/java/io/kraken/client/impl/ManualTest.java
@@ -46,6 +46,6 @@ public class ManualTest {
                 .build();
 
         final SuccessfulUploadResponse successfulUploadResponse = krakenIoClient.directUpload(directFileUploadRequest);
-        System.out.println(successfulUploadResponse.getKrakedUrl());
+        System.out.println(successfulUploadResponse);
     }
 }

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestCallbackUrlResize.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestCallbackUrlResize.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": false,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestCallbackUrlSimple.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestCallbackUrlSimple.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": false,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectCallbackUrlResize.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectCallbackUrlResize.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": false,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectCallbackUrlSimple.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectCallbackUrlSimple.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": false,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectResize.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectResize.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": true,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectSimple.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestDirectSimple.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": true,
     "webp": false,
     "lossy": false

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestImageUrlResize.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestImageUrlResize.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": true,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/io/kraken/client/impl/krakenIoRequestImageUrlSimple.json
+++ b/src/test/resources/io/kraken/client/impl/krakenIoRequestImageUrlSimple.json
@@ -3,6 +3,7 @@
         "api_key": "somekey",
         "api_secret": "somesecret"
     },
+    "dev": false,
     "wait": true,
     "webp": false,
     "lossy": false,

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+        <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+</appender>
+<root level="WARN">
+    <appender-ref ref="STDOUT" />
+</root>
+</configuration>


### PR DESCRIPTION
This PR addresses issue #1 
- Library now supports API Sandbox "dev" flag.
- Tests no longer spit out contents of test jpegs directly to stdout by default.
- responses now have toString() json representations (falling back to Java-style if response cannot be parsed as JSON)
