### PR TITLE
Update on pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
         <arguments />
 
         <jersey.version>2.25</jersey.version>
-        <jackson.version>2.8.6</jackson.version>
+        <!--<jackson.version>2.8.6</jackson.version>-->
+	<jackson.version>2.9.8</jackson.version>
         <guava.version>18.0</guava.version>
         <findbugs.version>3.0.0</findbugs.version>
         <slf4j.version>1.7.23</slf4j.version>


### PR DESCRIPTION
I have paid account with kraken.io

kg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.6 is giving CRITICAL warning when OWASP Dependency Check is done. Available at https://www.owasp.org/index.php/OWASP_Dependency_Check 

please update <jackson.version>2.8.6</jackson.version> 

to the latest version with no deprecations