### PR TITLE
Upgrade deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <jersey.version>2.25</jersey.version>
         <!--<jackson.version>2.8.6</jackson.version>-->
-	<jackson.version>2.9.8</jackson.version>
+	<jackson.version>2.14.3</jackson.version>
         <guava.version>18.0</guava.version>
         <findbugs.version>3.0.0</findbugs.version>
         <slf4j.version>1.7.23</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 	<jackson.version>2.14.3</jackson.version>
         <guava.version>18.0</guava.version>
         <findbugs.version>3.0.0</findbugs.version>
-        <slf4j.version>1.7.23</slf4j.version>
+        <slf4j.version>2.0.7</slf4j.version>
 
         <junit.version>4.12</junit.version>
         <mockserver.version>3.9.17</mockserver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>
         <maven.surefire.report.plugin.version>2.14</maven.surefire.report.plugin.version>
         <maven.source.plugin.version>2.1.2</maven.source.plugin.version>
-        <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
         <maven.versions-maven-plugin>2.7</maven.versions-maven-plugin>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <jersey.version>2.25</jersey.version>
         <!--<jackson.version>2.8.6</jackson.version>-->
 	<jackson.version>2.14.3</jackson.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>32.1.2-jre</guava.version>
         <findbugs.version>3.0.0</findbugs.version>
         <slf4j.version>2.0.7</slf4j.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <java.version>1.7</java.version>
         <arguments />
 
-        <jersey.version>2.25</jersey.version>
+        <jersey.version>3.1.3</jersey.version>
         <!--<jackson.version>2.8.6</jackson.version>-->
 	<jackson.version>2.14.3</jackson.version>
         <guava.version>32.1.2-jre</guava.version>
@@ -99,9 +99,10 @@
             <artifactId>jersey-media-multipart</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <findbugs.version>3.0.0</findbugs.version>
         <slf4j.version>2.0.7</slf4j.version>
 
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
         <mockserver.version>3.9.17</mockserver.version>
-        <mockito.version>1.10.17</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
         <hemcrest.version>1.3</hemcrest.version>
 
         <unirest.version>1.4.7</unirest.version>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/kraken/client/impl/DefaultKrakenIoClient.java
+++ b/src/main/java/io/kraken/client/impl/DefaultKrakenIoClient.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import io.kraken.client.KrakenIoClient;
 import io.kraken.client.exception.KrakenIoException;
 import io.kraken.client.exception.KrakenIoRequestException;
@@ -40,13 +40,13 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.text.MessageFormat;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -70,7 +70,7 @@ public class DefaultKrakenIoClient implements KrakenIoClient {
 
     private static final int CLIENT_TIMEOUT = 3000;
 
-    private final javax.ws.rs.client.Client client;
+    private final jakarta.ws.rs.client.Client client;
     private final String apiKey;
     private final String apiSecret;
     private final String directUploadUrl;

--- a/src/main/java/io/kraken/client/model/resize/FillResize.java
+++ b/src/main/java/io/kraken/client/model/resize/FillResize.java
@@ -22,7 +22,7 @@ import io.kraken.client.model.RGBA;
 import io.kraken.client.model.Strategy;
 import io.kraken.client.serializer.RGBASerializer;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 


### PR DESCRIPTION
This PR upgrades the dependencies of the project to avoid using javax.* packages and use jakarta.* packages.
This will allow the project to work with modern environments (Spring 6, Spring Boot 3, Hibernate 6)

I also upgrade jackson and another dependencies to a more modern version, in this case I align the versions of Jackson an slf4j to the current version Spring Boot 3.x branch has, as indicated in https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/dependency-versions.html#appendix.dependency-versions

No code or behavior has been changed. Only dependencies.